### PR TITLE
change to error message for geolocation errors

### DIFF
--- a/src/helpers/data/filter-meeting-data.ts
+++ b/src/helpers/data/filter-meeting-data.ts
@@ -122,7 +122,7 @@ export function filterMeetingData(
             );
           },
           error => {
-            console.warn(`TSML UI geolocation error: ${error}`);
+            console.warn(`TSML UI geolocation error: ${error.message}`);
           },
           { timeout: 5000 }
         );


### PR DESCRIPTION
Trying to debug issues and noticed this will currently output as `TSML UI geolocation error: [object GeolocationPositionError]`  - [GeolocationPositionError docs](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError/message)