### PR TITLE
fix: mock window.matchMedia for Jest tests

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -10,6 +10,21 @@ if (!global.TextDecoder) {
   global.TextDecoder = TextDecoder;
 }
 
+// window.matchMedia doesn't exist in test environment
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
 global.React = React;
 
 const savedLocation = window.location;


### PR DESCRIPTION
Add matchMedia mock to jest.setup.js to resolve TypeError when running tests that use media queries or dark mode detection